### PR TITLE
Fixed malformed urls in page template.

### DIFF
--- a/src/util/template/pageTemplate.html
+++ b/src/util/template/pageTemplate.html
@@ -86,9 +86,9 @@
         ></script>
         <link
             rel="stylesheet"
-            href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/styles/stackoverflow-light.min.css"
+            href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/styles/stackoverflow-light.min.css"
         />
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js"></script>
         <title>Axe-core® Accessibility Results</title>
     </head>
     <main role="main">


### PR DESCRIPTION
In the current version of the page template, two URLs are malformed. This results in long loading times. The browser tries to find the files in the local file system instead of loading them from Cloudflare.

In this pull-request, the urls have been corrected so that a local version also loads quickly.